### PR TITLE
Remove debounce delay in frange & folding box examples.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 CLAUDE.md
 node_modules
+.DS_Store

--- a/showcase/foldingbox/src/App.tsx
+++ b/showcase/foldingbox/src/App.tsx
@@ -117,7 +117,7 @@ function App() {
           if (modular !== null && evaluateRef.current) {
             evaluateRef.current(modular);
           }
-        }, 150); // 150ms debounce delay
+        }, 0); // 150ms debounce delay
 
       } catch (error) {
         console.error("Error changing node property:", error);

--- a/showcase/frange/src/App.tsx
+++ b/showcase/frange/src/App.tsx
@@ -113,7 +113,7 @@ function App() {
           if (modular !== null && evaluateRef.current) {
             evaluateRef.current(modular);
           }
-        }, 150); // 150ms debounce delay
+        }, 0); // 150ms debounce delay
 
       } catch (error) {
         console.error("Error changing node property:", error);


### PR DESCRIPTION
This pull request includes adjustments to debounce delays in two files to improve responsiveness. The debounce delay has been reduced from 150ms to 0ms in both cases.

* [`showcase/foldingbox/src/App.tsx`](diffhunk://#diff-6d9026a70d2a4fb1d39694df2bb36507d7f19e66c9e475603a6a530cf36ccc0cL120-R120): Updated the debounce delay in the `setTimeout` function from 150ms to 0ms to enhance real-time responsiveness in the `App` component.
* [`showcase/frange/src/App.tsx`](diffhunk://#diff-98a7b74b24ca42ac6629fa48160dab9da7398e5cafa601c342b1b280c804a833L116-R116): Updated the debounce delay in the `setTimeout` function from 150ms to 0ms to improve responsiveness in the `App` component.